### PR TITLE
Fix typo with param count

### DIFF
--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -65,7 +65,7 @@ AMX_NATIVE_END
 /**
  * native DailyLogger(const name[], const filename[], int hour, int minute)
  */
-AMX_NATIVE(DailyLogger, 42)
+AMX_NATIVE(DailyLogger, 4)
 	// Get params
 	auto name = Logger::getString(amx, params[1]);
 	auto filename = Logger::getString(amx, params[2]);


### PR DESCRIPTION
This was causing a few SPDLog errors when using this function: 

`[SPDLog] Fatal Error calling 'DailyLogger': expecting >= 42 parameter(s), but found < 4`